### PR TITLE
fix for bug where some RHS values were dropped

### DIFF
--- a/pysmps/smps_loader.py
+++ b/pysmps/smps_loader.py
@@ -405,7 +405,9 @@ def load_mps(path):
             elif mode == CORE_FILE_RHS_MODE_NAME_GIVEN:
                 if line[0] != rhs_names[-1]:
                     raise Exception("Other RHS name was given even though name was set after RHS tag.")
-                rhs[line[0]][row_names.index(line[1])] = float(line[2])
+                for kk in range((len(line) - 1) // 2):
+                  idx = kk * 2
+                  rhs[line[0]][row_names.index(line[idx+1])] = float(line[idx+2])
             elif mode == CORE_FILE_RHS_MODE_NO_NAME:
                 try:
                     i = rhs_names.index(line[0])
@@ -413,7 +415,9 @@ def load_mps(path):
                     rhs_names.append(line[0])
                     rhs[line[0]] = np.zeros(len(row_names))
                     i = -1
-                rhs[line[0]][row_names.index(line[1])] = float(line[2])
+                for kk in range((len(line) - 1) // 2):
+                  idx = kk * 2
+                  rhs[line[0]][row_names.index(line[idx+1])] = float(line[idx+2])
             elif mode == CORE_FILE_BOUNDS_MODE_NAME_GIVEN:
                 if line[1] != bnd_names[-1]:
                     raise Exception("Other BOUNDS name was given even though name was set after BOUNDS tag.")
@@ -596,4 +600,4 @@ def load_2stage_problem(path):
     assert len(T) == len(q)
     
     return {"name": d["name"], "c": c, "A": A, "b": b, "q": q, "h": h, "T": T, "W": W, "p": p}
-    
+


### PR DESCRIPTION
Thanks for maintaining this package.

I came across cases where the RHS was not getting parsed correctly. For example the wikipedia example (https://en.wikipedia.org/wiki/MPS_(format)) here:
```
NAME          TESTPROB
ROWS
 N  COST
 L  LIM1
 G  LIM2
 E  MYEQN
COLUMNS
    XONE      COST                 1   LIM1                 1
    XONE      LIM2                 1
    YTWO      COST                 4   LIM1                 1
    YTWO      MYEQN               -1
    ZTHREE    COST                 9   LIM2                 1
    ZTHREE    MYEQN                1
RHS
    RHS1      LIM1                 5   LIM2                10
    RHS1      MYEQN                7
BOUNDS
 UP BND1      XONE                 4
 LO BND1      YTWO                -1
 UP BND1      YTWO                 1
ENDATA
```
was not getting parsed correctly. This MPS corresponds to this problem:
```
Optimize
 COST:    XONE + 4*YTWO + 9*ZTHREE
Subject To
 LIM1:    XONE + YTWO          <= 5
 LIM2:    XONE        + ZTHREE >= 10
 MYEQN:        - YTWO + ZTHREE  = 7
Bounds
       XONE <= 4
 -1 <= YTWO <= 1
End
```
but when parsed by pysmps it was returning:
```
>>> from pysmps import smps_loader as mps
>>> mps
<module 'pysmps.smps_loader' from '/Users/bodonoghue/git/pysmps/pysmps/smps_loader.py'>
>>> data = mps.load_mps('test.mps')
>>> data
('TESTPROB', 'COST', ['LIM1', 'LIM2', 'MYEQN'], ['XONE', 'YTWO', 'ZTHREE'], ['continuous', 'continuous', 'continuous'], ['L', 'G', 'E'], array([1., 4., 9.]),
array([[ 1.,  1.,  0.],
       [ 1.,  0.,  1.],
       [ 0., -1.,  1.]]), ['RHS1'], {'RHS1': array([5., 0., 7.])}, ['BND1'], {'BND1': {'LO': array([ 0., -1.,  0.]), 'UP': array([ 4.,  1., inf])}})
>>>
```
Note that RHS1 is missing the value of 10 in the middle. I noticed that the parsing logic didn't go to the end of the line when parsing out the RHS fields. With this fix it now returns:
```
>>> from pysmps import smps_loader as mps
>>> data = mps.load_mps('test.mps')
>>> data
('TESTPROB', 'COST', ['LIM1', 'LIM2', 'MYEQN'], ['XONE', 'YTWO', 'ZTHREE'], ['continuous', 'continuous', 'continuous'], ['L', 'G', 'E'], array([1., 4., 9.]),
array([[ 1.,  1.,  0.],
       [ 1.,  0.,  1.],
       [ 0., -1.,  1.]]), ['RHS1'], {'RHS1': array([ 5., 10.,  7.])}, ['BND1'], {'BND1': {'LO': array([ 0., -1.,  0.]), 'UP': array([ 4.,  1., inf])}})
```

Note: I have not exhaustively tested this and I don't fully understand the code or the format so this could be the wrong fix. I also didn't check to see if other fields are affected by the same issue, so it would be good to verify that they are not.



